### PR TITLE
Making the task accept a different key

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
 /*
  * grunt-po-json
- * 
+ *
  *
  * Copyright (c) 2014 Nicky Out
  * Licensed under the MIT license.
@@ -31,19 +31,27 @@ module.exports = function(grunt) {
     // Configuration to be run (and then tested).
     po_json: {
       default_options: {
-          "files": {
-              "tmp/default_options.json": "test/test.po"
+          'files': {
+              'tmp/default_options.json': 'test/test.po'
           }
       },
       custom_options: {
-          "options": {
-              "amd": true
+          'options': {
+              'amd': true
           },
-          "files": {
-              "tmp/custom_options.js": {
-                  "test": "test/test.po",
-                  "test2": "test/test2.po"
+          'files': {
+              'tmp/custom_options.js': {
+                  'test': 'test/test.po',
+                  'test2': 'test/test2.po'
               }
+          }
+      },
+      custom_option_key: {
+          'options': {
+              'useMsgctxtAsKey': true
+          },
+          'files': {
+              'tmp/custom_option_key.json': 'test/test3.po'
           }
       }
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Default value: `false`
 
 Wraps the result in a `define( );` call so you can use it as an amd module. You probably want your dest path to end with `.js` instead of `.json`.
 
+#### options.useMsgctxtAsKey
+Type: `Boolean`
+Default value: `false`
+
+Matches msgctxt and msgstr instead of msgid and msgstr.
+
 ### Files
 
 #### files[property]

--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
   "bugs": {
     "url": "https://github.com/nickyout/grunt-po-json/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "engines": {
     "node": ">= 0.8.0"
   },

--- a/tasks/po_json.js
+++ b/tasks/po_json.js
@@ -59,7 +59,10 @@ module.exports = function(grunt) {
         {
             case 'string':
                 poStr = safeReadFile(src);
-                poStrToObject(poStr, returnObj, src, false, options);
+
+                if (poStr) {
+                    poStrToObject(poStr, returnObj, src, false, options);       
+                }
 
                 break;
 
@@ -72,8 +75,11 @@ module.exports = function(grunt) {
                     }
 
                     poStr = safeReadFile(src[namespace]);
-                    returnObj[namespace] = {};
-                    poStrToObject(poStr, returnObj[namespace], src[namespace], false, options);
+
+                    if (poStr) {
+                        returnObj[namespace] = {};
+                        poStrToObject(poStr, returnObj[namespace], src[namespace], false, options);                   
+                    }
                 }
                 break;
         }
@@ -95,7 +101,7 @@ module.exports = function(grunt) {
     var safeReadFile = function(path)
     {
         if (!grunt.file.exists(path)) {
-            grunt.log.warn('Source file "' + path + '" not found.');
+            grunt.fail.warn('Source file "' + path + '" not found.');
             return null;
         } else {
             return grunt.file.read(path);

--- a/test/expected/custom_option_key.json
+++ b/test/expected/custom_option_key.json
@@ -1,0 +1,1 @@
+{"ctxt_single_line":"A single line string","ctxt_multi_line":"A multi line string","ctxt_another_single_line":"A single line string 2"}

--- a/test/po_json_test.js
+++ b/test/po_json_test.js
@@ -45,5 +45,15 @@ exports.po_json = {
         test.equal(actual, expected, 'Custom should have the same file contents. ');
 
         test.done();
+    },
+
+    custom_option_key: function(test) {
+        test.expect(1);
+
+        var actual = grunt.file.read('tmp/custom_option_key.json');
+        var expected = grunt.file.read('test/expected/custom_option_key.json');
+        test.equal(actual, expected, 'Custom key should have the same file contents.');
+
+        test.done();
     }
 };

--- a/test/test3.po
+++ b/test/test3.po
@@ -1,0 +1,43 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Test\n"
+"POT-Creation-Date: 2014-02-20 13:04+0100\n"
+"PO-Revision-Date: 2014-02-20 13:04+0100\n"
+"Last-Translator: Nicky Out <nickyout@gmail.com>\n"
+"Language-Team: Test team <nickyout@gmail.com>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.5.7\n"
+"X-Poedit-KeywordsList: _;gettext;gettext_noop\n"
+"X-Poedit-Basepath: .\n"
+"X-Poedit-Bookmarks: -1,-1,-1,-1,-1,29,-1,-1,-1,-1\n"
+
+# Single line
+msgctxt "ctxt_single_line"
+msgid "Single line id"
+msgstr "A single line string"
+
+# Multi line
+msgctxt "ctxt_multi"
+"_line"
+msgid ""
+    "Multi "
+  "line "
+"id"
+msgstr ""
+"A "
+  "multi "
+    "line "
+      "string"
+
+# Another Single line
+ msgctxt "ctxt_another_single_line"
+ msgid "Another single line id"
+ msgstr "A single line string 2"
+
+
+# Commented out
+#~ msgid "Commented id"
+#~ msgstr "Commented str"
+


### PR DESCRIPTION
Our translation files have the identifier in the msgctxt field instead of the msgid field. The msgid field is used for the original translation and is not unique.

I also made a change to the package.json to prevent the "missing licence" warning from an npm install.

Lastly, there are some changes to satisfy the jshint task.
